### PR TITLE
Fix critical math and logic bugs in genomic coordinates and TE counting

### DIFF
--- a/script/overlap.R
+++ b/script/overlap.R
@@ -11,8 +11,8 @@ intergenic = read.table(intergenic_file, stringsAsFactors=F)
 intronic = read.table(intronic_file, stringsAsFactors=F)
 antisense = read.table(antisense_file, stringsAsFactors=F)
 
-overlap$start <- as.numeric(apply(overlap,1,function(x){max(c(x[2],x[10]))}))
-overlap$end <- as.numeric(apply(overlap,1,function(x){min(c(x[3],x[11]))}))
+overlap$start <- pmax(overlap[,2], overlap[,10])
+overlap$end <- pmin(overlap[,3], overlap[,11])
 out <- overlap[!(overlap[,12] %in% c(intergenic[,4], intronic[,4], antisense[,4])),c(1,ncol(overlap)-1,ncol(overlap),4,12,6,1:14)]
 
 out_file = paste0(sample, ".TE.overlap.pos.bed")

--- a/script/teen.py
+++ b/script/teen.py
@@ -153,7 +153,7 @@ def telescope(args):
 
 			TE_id = attributes['transcript_id']
 			TE_name = attributes['gene_id']
-			family_id = TE_id.split('_')[0]
+			family_id = TE_id.rsplit('_', 3)[0]
 
 			if TE_id in TE_dict:
 				if family_id not in family_dict:

--- a/script/teen.py
+++ b/script/teen.py
@@ -187,7 +187,7 @@ def TEEN(args):
 	transcript_quant.to_csv(transcript_quant_out, sep='\t', index=0)
 
 	exon_quant = pd.merge(TE_exon, quant, on='transcript_id')
-	exon_quant['count'] = exon_quant['exon_length']*exon_quant['count']/exon_quant['eff_length']
+	exon_quant['count'] = exon_quant['exon_length']*exon_quant['count']/exon_quant['length']
 	exon_count = exon_quant.groupby('exon_class')['count'].apply(sum).reset_index()
 	exon_count['count'] = round(exon_count['count'],2)
 	exon_TPM = exon_quant.groupby('exon_class')['TPM'].apply(sum).reset_index()


### PR DESCRIPTION
Hello TERA team,

Thank you for developing this great pipeline for TE analysis.

While running the pipeline on my dataset, I encountered a few critical mathematical and logical bugs that silently compromise the biological validity and statistical accuracy of the outputs. I have grouped these specific critical fixes into this PR to ensure robust quantification and downstream compatibility (e.g., with DESeq2).

Here are the details of the fixes included in this PR:

### 1. Fix String Comparison Bug in Genomic Coordinates (`script/overlap.R`)
**Issue:** In R, using the `apply()` function on a dataframe containing mixed data types (e.g., character chromosome names and numeric coordinates) implicitly coerces all values into a character matrix. As a result, genomic coordinates (start/end positions) were evaluated as strings instead of numbers.
While this bug might seem to work correctly in ~99% of cases simply because overlapping genomic coordinates usually have the same number of digits (e.g., `max(c("45120000", "45120100"))` evaluates "correctly" to `"45120100"` by lexicographical chance), it catastrophically fails when coordinates cross digit boundaries.
For example, if a TE overlaps a gene at the 10Mb boundary, the string comparison `max(c("9999900", "10000100"))` evaluates to `"9999900"` because the string `"9"` is lexicographically greater than `"1"`. This results in completely corrupted start/end coordinates (and sometimes negative lengths) for boundary-spanning TEs, silently breaking the downstream chimeric/intronic classification logic.
**Fix:** Modified the logic to avoid `apply()` coercion on mixed data types by utilizing vectorized numeric operations, ensuring that all coordinate comparisons are evaluated strictly as integers.

### 2. Fix Count Inflation in Exon Distribution for DESeq2 Compatibility (`script/teen.py`)
**Issue:** When distributing transcript counts to exons, the code used `effective_length` as the denominator: `exon_length * count / effective_length`. Since `effective_length` is always shorter than the actual length, the sum of distributed exon counts exceeded the total transcript count, creating artificial count inflation. Furthermore, downstream differential expression tools like DESeq2 strictly require un-normalized, raw integer counts. Using `effective_length` inflates counts and violates the assumptions of DESeq2's negative binomial model.
**Fix:** Changed the denominator to the actual transcript length.
*Formula Fixed:* `exon_quant['count'] = exon_quant['exon_length'] * exon_quant['count'] / exon_quant['length']`

### 3. Fix TE Subfamily Name Truncation (`script/teen.py`)
**Issue:** The script used `TE_id.split('_')[0]` to extract the TE family name. This unintentionally truncated valid TE subfamilies that contain underscores in their names (e.g., `L1MdF_II` became `L1MdF`), leading to incorrect categorization of TE annotations.
**Fix:** Changed the extraction logic to `TE_id.rsplit('_', 3)[0]`. This safely removes only the coordinate suffixes (`_chr_start_end`) while preserving the exact subfamily name.
*Example:* `L1MdF_II_chr17_21021952_21022177`
* Before: `L1MdF`
* After: `L1MdF_II`

I hope these fixes are helpful for the community. Please let me know if you have any questions or need further modifications!