### PR TITLE
Fix silent parameter ignoring in SERVE and optimize STAR multimapping

### DIFF
--- a/script/SERVE.py
+++ b/script/SERVE.py
@@ -39,7 +39,9 @@ def STAR(args):
 		+' --outSAMtype BAM SortedByCoordinate' \
         	+' --outSAMattributes NH HI AS nM NM' \
 		+' --twopassMode Basic' \
-		+' --outSAMstrandField intronMotif'
+		+' --outSAMstrandField intronMotif' \
+    	+' --outFilterMultimapNmax 100' \
+		+' --winAnchorMultimapNmax 100'
 		
     if args.nthreadsort:
         cmd += ' --outBAMsortingThreadN '+str(args.nthreadsort)

--- a/script/SERVE.py
+++ b/script/SERVE.py
@@ -102,6 +102,7 @@ def Remap(args):
 		+' -f gff3_gene' \
 		+' --max-intronlength-middle='+str(args.max_intron) \
 		+' --min-identity='+str(args.min_identity) \
+      	+' --min-trimmed-coverage='+str(args.min_coverage) \
 		+' '+ERV_fasta \
 		+' > '+ERV_gff3
 
@@ -126,6 +127,7 @@ parser.add_argument('-s', '--stranded_type', default=None, help='Strand-specific
 parser.add_argument('-m', '--nRAMassem', default='10G', help='Maximum available RAM (Gb) for assembly (default: 10G)')
 parser.add_argument('--max_intron', default=10000, type=int, help='Maximum intron length of ERVs (default: 10000)')
 parser.add_argument('--min_identity', default=0.95, help='Minimum identity of ERV transcripts (default: 0.95)')
+parser.add_argument('--min_coverage', default=0.95, help='Minimum coverage of ERV transcripts (default: 0.95)')
 parser.add_argument('--count', default=5, help='Minimum ERV count (default: 5)')
 parser.add_argument('-o', '--output_dir', default='.', help='Output directory (default: .)')
 

--- a/script/teen.py
+++ b/script/teen.py
@@ -98,7 +98,9 @@ def STAR(args):
 		+' --outSAMtype BAM SortedByCoordinate' \
         	+' --outSAMattributes NH HI AS nM NM' \
 		+' --twopassMode Basic' \
-		+' --outSAMstrandField intronMotif'
+		+' --outSAMstrandField intronMotif' \
+  		+' --outFilterMultimapNmax 100' \
+		+' --winAnchorMultimapNmax 100'
 
 	if fastq1.endswith('.gz'):
 		cmd += ' --readFilesCommand zcat'

--- a/script/tera.py
+++ b/script/tera.py
@@ -56,7 +56,9 @@ def STAR(args):
 		+' --outSAMtype BAM SortedByCoordinate' \
         	+' --outSAMattributes NH HI AS nM NM' \
 		+' --twopassMode Basic' \
-		+' --outSAMstrandField intronMotif'
+		+' --outSAMstrandField intronMotif' \
+    	+' --outFilterMultimapNmax 100' \
+		+' --winAnchorMultimapNmax 100'
 
 	if fastq1.endswith('.gz'):
 		cmd += ' --readFilesCommand zcat'

--- a/script/tera.py
+++ b/script/tera.py
@@ -144,6 +144,9 @@ def SERVE(args):
 		+' -g '+args.GMAP_index_name \
 		+' -t '+str(args.nthread) \
 		+' -m '+args.nRAMassem \
+		+' --max_intron '+str(args.max_intron) \
+		+' --min_identity '+str(args.min_identity) \
+		+' --min_coverage '+str(args.min_coverage) \
 		+' --count 1'
 	if args.stranded_type:
 		cmd += ' -s '+args.stranded_type


### PR DESCRIPTION
Hello TERA team,

This is the second PR in my series of updates to improve the robustness and usability of the TERA pipeline. This PR focuses on ensuring user-defined parameters are correctly respected by subprocesses and optimizing the mapping stringency for TE analysis.

Here are the details of the fixes and enhancements included in this PR:

### 1. Fix Silent Parameter Ignoring and Restore Coverage Filtering (`script/tera.py`, `script/SERVE.py`)
**Issue:** User-defined arguments like `--max_intron`, `--min_identity`, and `--min_coverage` were not passed from `tera.py` to the `SERVE.py` subprocess. Even worse, `SERVE.py` lacked an `argparse` receiver for `--min_coverage` and failed to pass it to the gmap execution command. Consequently, gmap silently fell back to its default coverage threshold of 0.0. This severe flaw allowed a massive amount of false-positive assembly artifacts (fake chimeras) to bypass the intended 0.95 stringency filter, compromising the biological validity of the de novo transcripts.
**Fix:** * Explicitly appended the missing arguments to the command string executing `SERVE.py` in `tera.py`.
* Added `-min_coverage` to `SERVE.py`'s parser and properly passed it to the gmap command via the `-min-trimmed-coverage` parameter to restore the strict filtering of artifacts.

### 2. Optimize STAR Multimapping for TEs (`script/tera.py`, `script/teen.py`)
**Issue:** In detect mode, STAR's default `--outFilterMultimapNmax` is too stringent (defaulting to 10). This silently discards a massive amount of valid reads originating from evolutionarily young or highly abundant TEs, undermining the core purpose of a TE analysis pipeline.
**Fix:** Added `--outFilterMultimapNmax 100` and `--winAnchorMultimapNmax 100` to the STAR execution command to retain multimapped reads. This aligns with the standard best practices established by other major TE analysis tools, such as TEtranscripts, ensuring that these reads are properly passed to downstream EM-based quantification.

Thank you for reviewing! Please let me know if you need any further modifications.